### PR TITLE
Add ability to expand environment variables and one more special variable in file pathes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It will help you to create such an managed storage manifest with exported config
 (Please remind that you should remove `"debug":true` from the managed manifest.)
 
 `itemsFile` under `overrideBaseRules` or other configs will contain path to a pattern file.
-It is regularly a complete file path on the platform, but you can use environment variables with formats "%VAR%", "$VAR", or "${VAR}".
+It is regularly a complete file path on the platform, but you can use environment variables with formats `%VAR%` or `${VAR}`.
 For example:
 
 ```json
@@ -83,6 +83,7 @@ For example:
 ```
 
 `ParentProcessDir` is a special variable which will be expanded to the path to the directory Thunderbird is installed.
+`"%VAR%"` style is available only at the beginning of the path, for safety.
 
 
 ## For Developers

--- a/README.md
+++ b/README.md
@@ -53,6 +53,38 @@ For example, if you use the `policies.json`:
 It will help you to create such an managed storage manifest with exported configs: FlexConfirmMail options => "Development" => Check "Debug mode" => "All Configs" => "Export".
 (Please remind that you should remove `"debug":true` from the managed manifest.)
 
+`itemsFile` under `overrideBaseRules` or other configs will contain path to a pattern file.
+It is regularly a complete file path on the platform, but you can use environment variables with formats "%VAR%", "$VAR", or "${VAR}".
+For example:
+
+```json
+{
+  "policies": {
+    "3rdparty": {
+      "Extensions": {
+        "flexible-confirm-mail-progressive@clear-code.com": {
+          "overrideBaseRules": [
+            { "id": "builtInAttentionDomains" },
+            { "id": "builtInAttentionSuffixes" },
+            { "id": "builtInAttentionSuffixes2" },
+            {
+               "id": "builtInAttentionTerms",
+               "enabled": true,
+               "itemsSource": 1,
+               "itemsFile": "${ParentProcessDir}\\distribution\\attention_terms.csv"
+            },
+            { "id": "builtInBlockedDomains" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+`ParentProcessDir` is a special variable which will be expanded to the path to the directory Thunderbird is installed.
+
+
 ## For Developers
 
 ### How to run automated unittest?

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.2.8"
+const VERSION = "4.2.9"
 
 var RunInCLI bool
 var DebugLogs []string

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -17,6 +17,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -242,8 +244,102 @@ func FetchAndRespond(path string, output io.Writer) error {
 	return nil
 }
 
+func IsParentProcessDirKey(key string) bool {
+	return strings.EqualFold(key, "ParentProcessDir")
+}
+
+func ExpandParentProcessDir(path string) (string, error) {
+	if !strings.Contains(strings.ToLower(path), "parentprocessdir") {
+		return path, nil
+	}
+
+	dir, err := GetParentProcessDir()
+	if err != nil {
+		return "", err
+	}
+
+	patterns := []string{
+		`%ParentProcessDir%`,
+		`$ParentProcessDir`,
+		`${ParentProcessDir}`,
+	}
+
+	result := path
+
+	for _, p := range patterns {
+		re := regexp.MustCompile(`(?i)` + regexp.QuoteMeta(p))
+		result = re.ReplaceAllString(result, dir)
+	}
+
+	return result, nil
+}
+
+func GetEnvVarValue(name string) string {
+	val := os.Getenv(name)
+	if val == "" {
+		val = os.Getenv(strings.ToUpper(name))
+	}
+	if val == "" {
+		val = os.Getenv(strings.ToLower(name))
+	}
+	return val
+}
+
+func ExpandAllEnvVars(path string) string {
+	// %VAR% format (for Windows)
+	rePercent := regexp.MustCompile(`%([^%]+)%`)
+	path = rePercent.ReplaceAllStringFunc(path, func(m string) string {
+		key := strings.Trim(m, "%")
+		if IsParentProcessDirKey(key) {
+			return m
+		}
+		val := GetEnvVarValue(key)
+		if val == "" {
+			return m
+		}
+		return val
+	})
+
+	// ${VAR} format (for Linux, macOS)
+	reBrace := regexp.MustCompile(`\$\{([^}]+)\}`)
+	path = reBrace.ReplaceAllStringFunc(path, func(m string) string {
+		key := m[2 : len(m)-1]
+		if IsParentProcessDirKey(key) {
+			return m
+		}
+		val := GetEnvVarValue(key)
+		if val == "" {
+			return m
+		}
+		return val
+	})
+
+	// $VAR format (for Linux, macOS)
+	reDollar := regexp.MustCompile(`\$(\w+)`)
+	path = reDollar.ReplaceAllStringFunc(path, func(m string) string {
+		key := m[1:]
+		if IsParentProcessDirKey(key) {
+			return m
+		}
+		val := GetEnvVarValue(key)
+		if val == "" {
+			return m
+		}
+		return val
+	})
+
+	return path
+}
+
 func Fetch(path string) (contents string, errorMessage string) {
-	buffer, err := ioutil.ReadFile(path)
+	pathWithExpandedParentProcessDir, err := ExpandParentProcessDir(path)
+	if err != nil {
+		return "", path + ": Failed to resolve parent process dir: " + err.Error()
+	}
+
+	pathWithExpandedEnvVars := ExpandAllEnvVars(pathWithExpandedParentProcessDir)
+
+	buffer, err := ioutil.ReadFile(pathWithExpandedEnvVars)
 	if err != nil {
 		return "", path + ": " + err.Error()
 	}

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -286,8 +286,8 @@ func GetEnvVarValue(name string) string {
 }
 
 func ExpandAllEnvVars(path string) string {
-	// %VAR% format (for Windows)
-	rePercent := regexp.MustCompile(`%([^%]+)%`)
+	// %VAR% format (for Windows, allowed only at the beginning of the input string)
+	rePercent := regexp.MustCompile(`^%([^%]+)%`)
 	path = rePercent.ReplaceAllStringFunc(path, func(m string) string {
 		key := strings.Trim(m, "%")
 		if IsParentProcessDirKey(key) {
@@ -304,20 +304,6 @@ func ExpandAllEnvVars(path string) string {
 	reBrace := regexp.MustCompile(`\$\{([^}]+)\}`)
 	path = reBrace.ReplaceAllStringFunc(path, func(m string) string {
 		key := m[2 : len(m)-1]
-		if IsParentProcessDirKey(key) {
-			return m
-		}
-		val := GetEnvVarValue(key)
-		if val == "" {
-			return m
-		}
-		return val
-	})
-
-	// $VAR format (for Linux, macOS)
-	reDollar := regexp.MustCompile(`\$(\w+)`)
-	path = reDollar.ReplaceAllStringFunc(path, func(m string) string {
-		key := m[1:]
 		if IsParentProcessDirKey(key) {
 			return m
 		}

--- a/webextensions/native-messaging-host/host_darwin.go
+++ b/webextensions/native-messaging-host/host_darwin.go
@@ -13,6 +13,11 @@ import (
 	"github.com/lhside/chrome-go"
 	"github.com/ncruces/zenity"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 func ChooseFile(params RequestParams) (path string, errorMessage string) {
@@ -44,4 +49,33 @@ func FetchOutlookGPOConfigsAndResponse(output io.Writer) error {
 		return err
 	}
 	return nil
+}
+
+func GetParentProcessBinPath() (string, error) {
+	ppid := os.Getppid()
+
+	out, err := exec.Command("ps", "-p", strconv.Itoa(ppid), "-o", "comm=").Output()
+	if err != nil {
+		return "", err
+	}
+
+	binPath := strings.TrimSpace(string(out))
+	return binPath, nil
+}
+
+func GetParentProcessDir() (string, error) {
+	binPath, err := GetParentProcessBinPath()
+	if err != nil {
+		return "", err
+	}
+
+	if !filepath.IsAbs(binPath) {
+		full, err := exec.LookPath(binPath)
+		if err == nil {
+			binPath = full
+		}
+	}
+
+	dir := filepath.Dir(binPath)
+	return dir, nil
 }

--- a/webextensions/native-messaging-host/host_other.go
+++ b/webextensions/native-messaging-host/host_other.go
@@ -19,3 +19,7 @@ func ChooseFile(params RequestParams) (path string, errorMessage string) {
 func FetchOutlookGPOConfigsAndResponse(output io.Writer) error {
 	return nil
 }
+
+func GetParentProcessDir() (string, error) {
+	return "", nil
+}

--- a/webextensions/native-messaging-host/host_test.go
+++ b/webextensions/native-messaging-host/host_test.go
@@ -179,16 +179,16 @@ func TestFetch_EnvironmentVariableExpansion(t *testing.T) {
 			path: "%TEST_FETCH_DIR%/test.txt",
 		},
 		{
-			name: "dollar style",
-			path: "$TEST_FETCH_DIR/test.txt",
+			name: "percent style lowercase env name",
+			path: "%test_fetch_dir%/test.txt",
 		},
 		{
 			name: "brace style",
 			path: "${TEST_FETCH_DIR}/test.txt",
 		},
 		{
-			name: "lowercase env name",
-			path: "%test_fetch_dir%/test.txt",
+			name: "brace style lowercase env name",
+			path: "${test_fetch_dir}/test.txt",
 		},
 	}
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Currently the system administrator must specify a fixed path to pattern files with policies.
This change adds ability to use environment variables and one more special variable "ParentProcessDir" which will be expanded to the path to the directory Thunderbird is installed in.

# How to verify the fixed issue:

## The steps to verify:

1. Install FlexConfirmMail to your Thunderbird.
2. Install the built naive messaging host.
3. Go to about:debugging on Thunderbird.
4. Open the debugger for FlexConfirmMail.
5. Run a script: `browser.runtime.sendNativeMessage('com.clear_code.flexible_confirm_mail_we_host', {command:'fetch',params:{path:'${ParentProcessDir}\\application.ini'} }).then(console.log)`

## Expected result:

The response contains the contents of the file "application.ini".