### PR TITLE
Fix file chooser dialog

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.9",
+  "version": "4.2.10",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -338,7 +338,6 @@ type ChooseFileResponse struct {
 }
 
 func ChooseFileAndRespond(params RequestParams, output io.Writer) error {
-	LogForDebug("ChooseFileAndRespond called")
 	path, errorMessage := ChooseFile(params)
 	response := &ChooseFileResponse{path, errorMessage}
 	body, err := json.Marshal(response)

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.2.9"
+const VERSION = "4.2.10"
 
 var RunInCLI bool
 var DebugLogs []string

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -53,7 +53,7 @@ func LogForDebug(message string) {
 type RequestParams struct {
 	Path             string `json:"path"`
 	Title            string `json:"title"`
-	Role             string `json:"role"`
+	Role             string `json:"role"` // obsolete, not used
 	FileName         string `json:"fileName"`
 	DefaultExtension string `json:"defaultExtension"`
 	DisplayName      string `json:"displayName"`

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -338,6 +338,7 @@ type ChooseFileResponse struct {
 }
 
 func ChooseFileAndRespond(params RequestParams, output io.Writer) error {
+	LogForDebug("ChooseFileAndRespond called")
 	path, errorMessage := ChooseFile(params)
 	response := &ChooseFileResponse{path, errorMessage}
 	body, err := json.Marshal(response)

--- a/webextensions/native-messaging-host/host_windows.go
+++ b/webextensions/native-messaging-host/host_windows.go
@@ -78,7 +78,6 @@ func BuildFilter(displayName, pattern string) *uint16 {
 }
 
 func ChooseFile(params RequestParams) (path string, errorMessage string) {
-	LogForDebug("ChooseFile called")
 	buf := make([]uint16, syscall.MAX_PATH)
 
 	LogForDebug("ChooseFile, filename = " + params.FileName)

--- a/webextensions/native-messaging-host/host_windows.go
+++ b/webextensions/native-messaging-host/host_windows.go
@@ -78,6 +78,7 @@ func BuildFilter(displayName, pattern string) *uint16 {
 }
 
 func ChooseFile(params RequestParams) (path string, errorMessage string) {
+	LogForDebug("ChooseFile called")
 	buf := make([]uint16, syscall.MAX_PATH)
 
 	LogForDebug("ChooseFile, filename = " + params.FileName)

--- a/webextensions/native-messaging-host/host_windows.go
+++ b/webextensions/native-messaging-host/host_windows.go
@@ -80,6 +80,7 @@ func BuildFilter(displayName, pattern string) *uint16 {
 func ChooseFile(params RequestParams) (path string, errorMessage string) {
 	buf := make([]uint16, syscall.MAX_PATH)
 
+	LogForDebug("ChooseFile, filename = " + params.FileName)
 	if params.FileName != "" {
 		copy(buf, syscall.StringToUTF16(params.FileName))
 	}
@@ -97,6 +98,7 @@ func ChooseFile(params RequestParams) (path string, errorMessage string) {
 
 	ret, _, err := ProcGetOpenFileNameW.Call(uintptr(unsafe.Pointer(&ofn)))
 	if ret == 0 {
+		LogForDebug("Canceled or failed: " + err.Error())
 		return "", err.Error()
 	}
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

As mentioned at comments in #89, the file chooser dialog is not available (maybe on Windows 11). After some investigation I've realized that go-common-file-dialog is not available to open file chooser dialog from any console applications including native messaging hosts, and direct call of Windows APIs looks to solve that. This PR renews the implementation towith the one based on Windows native APIs.

# How to verify the fixed issue:

## The steps to verify:

1. Build the native messaging host from the branch.
2. Install it.
3. Click the "Choose..." button in any custom rule in the options page of FlexConfirmMail.

## Expected result:

A file chooser dialog is opened.