### PR TITLE
Update RichConfirm library for Thunderbird 149 and later

### DIFF
--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -33,7 +33,7 @@ install_extlib:
 	cp ../submodules/webextensions-lib-configs/Configs.js extlib/; echo 'export default Configs;' >> extlib/Configs.js
 	cp ../submodules/webextensions-lib-options/Options.js extlib/; echo 'export default Options;' >> extlib/Options.js
 	cp ../submodules/webextensions-lib-l10n/l10n.js extlib/; echo 'export default l10n;' >> extlib/l10n.js
-	cp ../submodules/webextensions-lib-rich-confirm/RichConfirm.js extlib/; echo 'export default RichConfirm;' >> extlib/RichConfirm.js
+	cp ../submodules/webextensions-lib-rich-confirm/RichConfirm* extlib/
 	cp ../submodules/webextensions-lib-dialog/dialog.js extlib/
 	cp ../submodules/webextensions-lib-dialog/dialog.css extlib/
 	cp ../submodules/webextensions-lib-dom-updater/src/diff.js extlib/

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -28,6 +28,8 @@ const TYPE_DRAFT            = 'draft';
 const TYPE_TEMPLATE         = 'template';
 const TYPE_EXISTING_MESSAGE = 'edit-as-new-message';
 
+RichConfirm.init('/extlib/RichConfirmDialog.html');
+
 function getMessageSignature(message) {
   const author = message.from || message.author || '';
   const authorAddressMatched = author.match(/<([^>]+)>$/);
@@ -408,7 +410,6 @@ async function shouldBlock(tab, details) {
         return RichConfirm.showInPopup(tab.windowId, {
           modal: !configs.debug,
           type:  'common-dialog',
-          url:   '/resources/blank.html',
           title,
           content: message,
           buttons: [

--- a/webextensions/dialog/confirm/confirm.js
+++ b/webextensions/dialog/confirm/confirm.js
@@ -41,6 +41,8 @@ let mAttachmentsList;
 let mAcceptButton;
 let mCancelButton;
 
+RichConfirm.init('/extlib/RichConfirmDialog.html');
+
 function onConfigChange(key) {
   const value = configs[key];
   switch (key) {
@@ -483,16 +485,13 @@ async function confirmedFailedLists() {
     result = await RichConfirm.show({
       modal: true,
       type:  'common-dialog',
-      url:   '/resources/blank.html',
       title: browser.i18n.getMessage('confirmUnpopulatableListsTitle'),
       content: message,
       buttons: [
         browser.i18n.getMessage('confirmUnpopulatableListsAccept'),
-        browser.i18n.getMessage('confirmUnpopulatableListsCancel')
+        browser.i18n.getMessage('confirmUnpopulatableListsCancel'),
       ],
-      onShown(content) {
-        content.closest('.rich-confirm-dialog').classList.add('for-unpopulatable-lists');
-      },
+      extraClass: 'for-unpopulatable-lists',
     });
   }
   catch(_error) {
@@ -527,16 +526,13 @@ async function confirmedMultipleRecipientDomains() {
     result = await RichConfirm.show({
       modal: true,
       type:  'common-dialog',
-      url:   '/resources/blank.html',
       title: configs.confirmMultipleRecipientDomainsDialogTitle || browser.i18n.getMessage('confirmMultipleRecipientDomainsTitle'),
       content: message,
       buttons: [
         browser.i18n.getMessage('confirmMultipleRecipientDomainsAccept'),
-        browser.i18n.getMessage('confirmMultipleRecipientDomainsCancel')
+        browser.i18n.getMessage('confirmMultipleRecipientDomainsCancel'),
       ],
-      onShown(content) {
-        content.closest('.rich-confirm-dialog').classList.add('for-multiple-recipient-domains');
-      },
+      extraClass: 'for-multiple-recipient-domains',
     });
   }
   catch(_error) {
@@ -570,16 +566,13 @@ async function confirmedNewDomainRecipients() {
     result = await RichConfirm.show({
       modal: true,
       type:  'common-dialog',
-      url:   '/resources/blank.html',
       title: configs.confirmNewDomainRecipientsDialogTitle || browser.i18n.getMessage('confirmNewDomainRecipientsDialogTitle'),
       content: message,
       buttons: [
         browser.i18n.getMessage('confirmNewDomainRecipientsAccept'),
-        browser.i18n.getMessage('confirmNewDomainRecipientsCancel')
+        browser.i18n.getMessage('confirmNewDomainRecipientsCancel'),
       ],
-      onShown(content) {
-        content.closest('.rich-confirm-dialog').classList.add('for-new-domain-recipients');
-      },
+      extraClass: 'for-new-domain-recipients',
     });
   }
   catch(_error) {
@@ -608,16 +601,13 @@ async function confirmedWithRules() {
         result = await RichConfirm.show({
           modal: true,
           type:  'common-dialog',
-          url:   '/resources/blank.html',
           title,
           content: message,
           buttons: [
             browser.i18n.getMessage('reconfirmAccept'),
             browser.i18n.getMessage('reconfirmCancel'),
           ],
-          onShown(content) {
-            content.closest('.rich-confirm-dialog').classList.add(`for-${rule.name.replace(/[\s\|:()\[\]<>{}!?*\.\/\\~+]/g, '_')}`);
-          },
+          extraClass: `for-${rule.name.replace(/[\s\|:()\[\]<>{}!?*\.\/\\~+]/g, '_')}`,
         });
       }
       catch(_error) {

--- a/webextensions/options/init.js
+++ b/webextensions/options/init.js
@@ -21,6 +21,8 @@ import { DOMUpdater } from '/extlib/dom-updater.js';
 import RichConfirm from '/extlib/RichConfirm.js';
 import { MatchingRules } from '/common/matching-rules.js';
 
+RichConfirm.init('/extlib/RichConfirmDialog.html');
+
 let mMatchingRules;
 
 const options = new Options(configs);
@@ -464,12 +466,11 @@ async function removeRule(id) {
     result = await RichConfirm.show({
       modal: true,
       type:  'common-dialog',
-      url:   '/resources/blank.html',
       message: browser.i18n.getMessage('config_userRules_remove_confirmMessage', [mMatchingRules.get(id).name]),
       buttons: [
         browser.i18n.getMessage('config_userRules_remove_accept'),
-        browser.i18n.getMessage('config_userRules_remove_cancel')
-      ]
+        browser.i18n.getMessage('config_userRules_remove_cancel'),
+      ],
     });
   }
   catch(_error) {
@@ -488,12 +489,11 @@ async function resetRuleItemsLocal(id) {
     result = await RichConfirm.show({
       modal: true,
       type:  'common-dialog',
-      url:   '/resources/blank.html',
       message: browser.i18n.getMessage('config_userRules_resetItemsLocal_confirmMessage', [mMatchingRules.get(id).name]),
       buttons: [
         browser.i18n.getMessage('config_userRules_reset_accept'),
-        browser.i18n.getMessage('config_userRules_reset_cancel')
-      ]
+        browser.i18n.getMessage('config_userRules_reset_cancel'),
+      ],
     });
   }
   catch(_error) {

--- a/webextensions/resources/blank.html
+++ b/webextensions/resources/blank.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<meta charset="UTF-8">
-<link rel="icon" href="./16x16.svg">
-<title></title>


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We cannot do dynamic injection of codes into pages included in a addon anymore on Firefox 149/Thunderbird 149 and later.
See: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/149#changes_for_add-on_developers

> The ability of extensions to dynamically execute code in their moz-extension: documents with [tabs.executeScript](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript), [tabs.insertCSS](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS), [tabs.removeCSS](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS), [scripting.executeScript](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript), [scripting.insertCSS](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/insertCSS), and [scripting.removeCSS](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/removeCSS) is deprecated. ([Firefox bug 2011234](https://bugzil.la/2011234)) The feature is no longer available in Firefox Nightly, and the beta and release versions of Firefox provide a warning in the tab's console. This restriction will apply to all versions of Firefox 152 and later. ([Firefox bug 2015559](https://bugzil.la/2015559)) As an alternative, an extension can run code in its documents dynamically by registering a [runtime.onMessage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage) listener in the document's script, then sending a message to trigger execution of the required code.

This PR updates the RichConfirm library depended to script injection to a new version with reduced script injection.

# How to verify the fixed issue:

## The steps to verify:

1. Install Thunderbird newer than 149.
2. Install this addon.
3. Add some rules to block sending.
4. Try to send a message to be blocked.

## Expected result:

A custom dialog describing the blocking is shown as expected.