### PR TITLE
Bump version to 4.2.5.3

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.2.5.2",
+  "version": "4.2.5.3",
   "author": "ClearCode Inc.",
   "description": "__MSG_extensionDescription__",
   "permissions": [

--- a/webextensions/native-messaging-host/host.go
+++ b/webextensions/native-messaging-host/host.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-const VERSION = "4.2.5.2"
+const VERSION = "4.2.5.3"
 
 var RunInCLI bool
 var DebugLogs []string


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This increments the version number.
I've verified this works as documented (with changes at #99 )

# How to verify the fixed issue:

## The steps to verify:

1. cd `webextensions` and run `make`.
2. Install built XPI.

## Expected result:

The version is displayed as 4.2.5.3.