### PR TITLE
Update RichConfirm with sanitization

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install gox
         run: go install github.com/mitchellh/gox@latest
       - name: Make xpi
-        run: cd webextensions && make install_dependency && make && cp *.xpi ..\
+        run: cd webextensions && make && cp *.xpi ..\
       - name: Make Installer
         run: make host
         env:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install gox
         run: go install github.com/mitchellh/gox@latest
       - name: Make xpi
-        run: cd webextensions && make && cp *.xpi ..\
+        run: cd webextensions && make install_dependency && make && cp *.xpi ..\
       - name: Make Installer
         run: make host
         env:

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -28,7 +28,7 @@ init_extlib:
 update_extlib:
 	git submodule foreach 'git checkout trunk || git checkout main || git checkout master && git pull'
 
-install_extlib:
+install_extlib: install_dependency
 	rm -f extlib/*.css extlib/*.html extlib/*.js extlib/*.map extlib/*.mjs
 	cp ../submodules/webextensions-lib-configs/Configs.js extlib/; echo 'export default Configs;' >> extlib/Configs.js
 	cp ../submodules/webextensions-lib-options/Options.js extlib/; echo 'export default Options;' >> extlib/Options.js

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -29,7 +29,7 @@ update_extlib:
 	git submodule foreach 'git checkout trunk || git checkout main || git checkout master && git pull'
 
 install_extlib:
-	rm -f extlib/*.js extlib/*.css
+	rm -f extlib/*.css extlib/*.html extlib/*.js extlib/*.map extlib/*.mjs
 	cp ../submodules/webextensions-lib-configs/Configs.js extlib/; echo 'export default Configs;' >> extlib/Configs.js
 	cp ../submodules/webextensions-lib-options/Options.js extlib/; echo 'export default Options;' >> extlib/Options.js
 	cp ../submodules/webextensions-lib-l10n/l10n.js extlib/; echo 'export default l10n;' >> extlib/l10n.js
@@ -38,6 +38,7 @@ install_extlib:
 	cp ../submodules/webextensions-lib-dialog/dialog.css extlib/
 	cp ../submodules/webextensions-lib-dom-updater/src/diff.js extlib/
 	cp ../submodules/webextensions-lib-dom-updater/src/dom-updater.js extlib/
+	cp $(CURDIR)/node_modules/dompurify/dist/purify.es.mjs* extlib/
 
 host:
 	cd native-messaging-host && make

--- a/webextensions/package.json
+++ b/webextensions/package.json
@@ -19,5 +19,8 @@
     "node-fetch": "^2.6.0",
     "tiny-esm-test-runner": "^0.0.5",
     "tunnel-agent": ">=0.6.0"
+  },
+  "devDependencies": {
+    "dompurify": "^3.4.1"
   }
 }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Updates RichConfirm to the version supporting sanitizing by DOMPurify, so FlexConfirmMail will become more safer for dangerous input given by the user.

# How to verify the fixed issue:

## The steps to verify:

1. Build XPI and install to Thunderbird.
2. Open the menubar (by Alt key) and go to "Tools" => "Developer Tools" => "Debug Add-ons".
3. Start Inspector for FlexConfirmMail.
4. Configure FlexConfirmMail to block sending messages to a recipient `forbidden@example.com`, and set the alert message as:
   ```html
   <script type="application/javascript">alert("DANGER");</script>
   ブロック対象のドメインに属する以下の宛先があります。
   
   <strong onclick="alert('DANGER')">$S</strong>
   
   これらの宛先にメールを送ることはできません。
   ```
5. Start composition of a message to a recipient `forbidden@example.com`.
6. Try to send the message.
7. Wait until a custom dialog with blocked message become open.
8. In the inspector, switch inspection target document to `extlib/RichConfirmDialog.html`.
9. Choose "Inspect" tab and inspect the contents of the message dialog.

## Expected result:

* No `<script>` element is embedded.
* No `onclick` event handler attribute is embedded.
